### PR TITLE
Various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ readme = "README.md"
 [dependencies]
 regex = "1"
 content_inspector = "0.2.4"
+lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub fn is_svg(filename: &str) -> Result<bool, Error> {
 
     let content_type = inspect(&data);
     if (content_type != ContentType::UTF_8) && (content_type != ContentType::UTF_8_BOM) {
-        unimplemented!("currently doesn't support UTF-8")
+        unimplemented!("currently doesn't support non UTF-8")
     } else {
         let joined = String::from_utf8(data)?;
         Ok(SVG_REGEX.is_match(&joined))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@ extern crate content_inspector;
 extern crate regex;
 
 use content_inspector::{inspect, ContentType};
+use lazy_static::lazy_static;
 use regex::Regex;
 use std::fs;
 use std::io;
 use std::string::FromUtf8Error;
-use lazy_static::lazy_static;
 
 lazy_static! { // using lazy_static because compiling regex is expensive
     static ref SVG_REGEX: Regex = Regex::new(r"(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b")
@@ -25,8 +25,9 @@ pub fn is_svg(filename: &str) -> Result<bool, Error> {
     }
 }
 
+// so that we can return our own appropriate error
 #[derive(Debug)]
-pub enum Error { // so that we can return our own appropriate error
+pub enum Error {
     IOError(io::Error),
     Utf8ParseError(FromUtf8Error),
 }
@@ -35,7 +36,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(match self {
             Error::IOError(e) => e,
-            Error::Utf8ParseError(e) => e
+            Error::Utf8ParseError(e) => e,
         })
     }
 }
@@ -44,7 +45,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::IOError(e) => write!(f, "couldn't read from file: {}", e),
-            Error::Utf8ParseError(e) => write!(f, "couldn't parse utf-8: {}", e)
+            Error::Utf8ParseError(e) => write!(f, "couldn't parse utf-8: {}", e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,20 +4,59 @@ extern crate regex;
 use content_inspector::{inspect, ContentType};
 use regex::Regex;
 use std::fs;
+use std::io;
+use std::string::FromUtf8Error;
+use lazy_static::lazy_static;
 
-pub fn is_svg(filename: &str) -> &str {
-    let data = fs::read(&filename).expect("Unable to read file");
-    if inspect(&data) == ContentType::BINARY {
-        return "binary file please check imghdr to check this file";
+lazy_static! { // using lazy_static because compiling regex is expensive
+    static ref SVG_REGEX: Regex = Regex::new(r"(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b")
+    .unwrap(); // this is OK because we know that the regex compiles
+}
+
+pub fn is_svg(filename: &str) -> Result<bool, Error> {
+    let data = fs::read(&filename)?;
+
+    let content_type = inspect(&data);
+    if (content_type != ContentType::UTF_8) && (content_type != ContentType::UTF_8_BOM) {
+        unimplemented!("currently doesn't support UTF-8")
     } else {
-        let _re =
-            Regex::new(r"(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b")
-                .unwrap();
-        let joined = std::str::from_utf8(&data).unwrap();
-        if _re.is_match(joined) {
-            return "yes it is a svg file";
-        } else {
-            return "Not an svg file or corrupted file";
+        let joined = String::from_utf8(data)?;
+        Ok(SVG_REGEX.is_match(&joined))
+    }
+}
+
+#[derive(Debug)]
+pub enum Error { // so that we can return our own appropriate error
+    IOError(io::Error),
+    Utf8ParseError(FromUtf8Error),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(match self {
+            Error::IOError(e) => e,
+            Error::Utf8ParseError(e) => e
+        })
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::IOError(e) => write!(f, "couldn't read from file: {}", e),
+            Error::Utf8ParseError(e) => write!(f, "couldn't parse utf-8: {}", e)
         }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::IOError(e)
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8ParseError(e)
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,16 +1,9 @@
-extern crate is_svg;
-
 #[test]
 fn test_png() {
-    assert_eq!(
-        is_svg::is_svg("./images/example.png"),
-        "please check imghdr to check this file"
-    );
+    assert_eq!(is_svg::is_svg("./images/example.png").unwrap(), false);
+    // should it be false? maybe this should be changed accordingly
 }
 #[test]
 fn test_jpeg() {
-    assert_eq!(
-        is_svg::is_svg("./images/example.svg"),
-        "yes it is a svg file"
-    );
+    assert_eq!(is_svg::is_svg("./images/example.svg").unwrap(), true);
 }


### PR DESCRIPTION
Hi!
I've reviewed your library as discussed in discord, and implemented various improvements that I think are suitable:
- Created a custom error type for the library, which can be used in `Result`s instead of panicking/returning a string
- Moved regex compilation to a lazy_static, so that the regex will only be compiled once instead of each time the function runs (the latter is very inefficient)
- Instead of returning an error when the file isn't UTF-8, I think it's more appropriate to panic with an unimplemented message because the library should support all types of SVG files if it claims to check such a property
- Changed the tests accordingly

Let me know if you see anything unsatisfactory. Be sure to look at the first integration test to see if it's correct, and also consider making these unit tests instead since they seem smaller than integration tests (could just be my opinion)